### PR TITLE
Rubocop prime file

### DIFF
--- a/.rubocop-prime.yml
+++ b/.rubocop-prime.yml
@@ -1,0 +1,18 @@
+inherit_from: .rubocop.yml
+
+# https://github.com/mynewsdesk/mynewsdesk/pull/3058
+Metrics/AbcSize:
+  Enabled: false
+Metrics/BlockLength:
+  Enabled: false
+Metrics/MethodLength:
+  Enabled: false
+
+Metrics/ClassLength:
+  Enabled: false
+Metrics/ModuleLength:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false

--- a/README.md
+++ b/README.md
@@ -39,3 +39,11 @@ inherit_gem:
 That takes care of inheriting from the base `.rubocop.yml` contained in this gem.
 
 Follow/Override any other value as you would normally do in your local `.rubocop.yml` file.
+
+Or, to have just the same rules as Prime in your application, use the Prime config file:
+
+```yaml
+#.rubocop.yml
+inherit_gem:
+  mnd-rubocop: .rubocop-prime.yml
+```

--- a/mnd-rubocop.gemspec
+++ b/mnd-rubocop.gemspec
@@ -1,13 +1,13 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name        = "mnd-rubocop"
-  spec.version     = "0.0.1"
-  spec.date        = "2018-01-24"
+  spec.version     = "0.0.2"
+  spec.date        = "2018-01-25"
   spec.summary     = "Shared Rubocop config to be included in MND apps"
   spec.description = ""
   spec.authors       = ["Mynewsdesk"]
   spec.email         = ["dev@mynewsdesk.com"]
-  spec.files       = [".rubocop.yml"]
+  spec.files       = [".rubocop.yml", ".rubocop-prime.yml"]
   spec.homepage    = "https://www.mynewsdesk.com"
   spec.license       = "MIT"
   spec.add_runtime_dependency "rubocop", "~> 0"


### PR DESCRIPTION
Adding a Rubocop file specific for Prime.
This follows https://github.com/mynewsdesk/mnd-content-marketplace-backend/pull/35 once it gets approved, this should add an additional file, specific for Prime. Purpose of this is to being able to include a single .rubocop-prime.yml (e.g. in Social Media Monitor) to have the same config as Prime out of the box.
Vote up or down?