### PR TITLE
Update settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ build-iPhoneSimulator/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+.DS_Store
+.idea/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Style/GuardClause:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-# https://github.com/mynewsdesk/mnd-rubocop/pull/1
+# https://github.com/mynewsdesk/mnd-rubocop/pull/2
 # (change TrailingCommaInLiteral to TrailingCommaInArrayLiteral & TrailingCommaInHashLiteral)
 Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,12 @@ Style/GuardClause:
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 
-Style/TrailingCommaInLiteral:
+# https://github.com/mynewsdesk/mnd-rubocop/pull/1
+# (change TrailingCommaInLiteral to TrailingCommaInArrayLiteral & TrailingCommaInHashLiteral)
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 Style/TrailingCommaInArguments:


### PR DESCRIPTION
Rubocop split up the cop `Style/TrailingCommaInLiteral` into `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral`. This PR reflects this without making changes to the rule.

I also added `.DS_Store` and `.idea` to `.gitignore`.