### PR TITLE
Disable Style/IfUnlessModifier

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -29,6 +29,10 @@ Metrics/LineLength:
 Style/GuardClause:
   Enabled: false
 
+# https://github.com/mynewsdesk/mnd-rubocop/pull/3
+Style/IfUnlessModifier:
+  Enabled: false
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 


### PR DESCRIPTION
# What is does now

The `Style/IfUnlessModifier` is described as follows:

Checks for if and unless statements that would fit on one line if written as a modifier if/unless. The maximum line length is configured in the `Metrics/LineLength` cop. The tab size is configured in the `IndentationWidth` of the `Layout/Tab` cop.

## Examples

```ruby
# bad
if condition
  do_stuff(bar)
end

unless qux.empty?
  Foo.do_something
end

# good
do_stuff(bar) if condition
Foo.do_something unless qux.empty?
```

# Why I want to disable it

1. The decision to use if/unless inline or in it's block form should be left to the developer. Depending what style you use you draw the attention of the reader either to the condition or to the code which is executed on true/false. In my opinion inline style is nice for guard clauses (`return unless ...`) but should be used with caution in the "method body" (i.e. what comes after the guard clauses) because it it turns the control flow from head to toe (you first read the code to execute and afterwards the condition if it is executed or not) and is therefore harder to read.

2. Our line length is set to 128. We chose not to change this because it would cause to many violations. However, as far as I understand we have a "soft agreement" that 128 characters is actually too long. This amplifies my objections above because when you are using 128 characters with an inline if/unless it's nearly guaranteed that you overlook the if/unless at the end of the line.