### PR TITLE
Exclude checks for automatically generated rails files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,10 +1,11 @@
 AllCops:
-# Exclude/Include params should lie in the including .rubocop file
-# Ref. http://rubocop.readthedocs.io/en/latest/configuration/#inheritance
-#  Exclude:
-#    - 'db/schema.rb'
-#    - bin/**
-
+  # Exclude automatically generated rails files for easier app:update's etc
+  Exclude:
+    - bin/*
+    - db/schema.rb
+    - config/boot.rb
+    - config/environments/*
+    - vendor/**/*
   DisplayCopNames: true
 
 # https://github.com/mynewsdesk/mynewsdesk/pull/3197


### PR DESCRIPTION
This makes handling `rails app:update` a lot cleaner since we can keep the generated code as is and add our own modifications to the bottom of the files.

Some of these rules are already applied locally such as in `mynewsdesk`(https://github.com/mynewsdesk/mynewsdesk/blob/master/.rubocop.yml#L5-L6) and `content-marketplace-backend` (https://github.com/mynewsdesk/mnd-content-marketplace-backend/blob/master/.rubocop.yml#L8-L12) Centralising it will make rails updates easier across all apps without need for explicit local rules.

As an example of the kind of noise we get without exclude you may take a look at the current state of the Rails upgrade in `audience`: https://github.com/mynewsdesk/audience/pull/42

I've confirmed that rubocop is fine with Exclude directives for folders and files which are not actually present on the file system (so this can be safely used with all types of ruby repos).