### PR TITLE
Disable DoubleNegation rule.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,3 +54,6 @@ Style/FrozenStringLiteralComment:
 
 Style/Documentation:
   Enabled: false
+
+Style/DoubleNegation:
+  Enabled: false


### PR DESCRIPTION
It is not helpful when trying to enforce types for APIs etc.