### PR TITLE
Allow long lines including URL’s

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,7 @@ Layout/MultilineMethodCallIndentation:
 # https://github.com/mynewsdesk/mynewsdesk/pull/3205
 Metrics/LineLength:
   Max: 128
+  AllowURI: true # https://github.com/mynewsdesk/mnd-rubocop/pull/6
 
 # https://github.com/mynewsdesk/mynewsdesk/pull/3520
 Style/GuardClause:


### PR DESCRIPTION
Avoids these kind of violations which doesn't make much sense to split across multiple lines:

<img width="949" alt="Screenshot 2020-06-25 at 14 06 46" src="https://user-images.githubusercontent.com/3461/85716806-1be94c00-b6ed-11ea-8ff2-8c3d85d2edba.png">

There are a whole bunch of them on this PR and seems like noise to me: https://github.com/mynewsdesk/mynewsdesk/pull/7502

The `AllowURI` option is listed in [the rubocop documentation](https://docs.rubocop.org/rubocop/0.86/cops_layout.html#examples-50) but not actually explained. It essentially disables the line length check if the line matches their URL regex.