### PR TITLE
Fix error message about rubocop-rspec_rails

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 require:
   - rubocop-rails
   - rubocop-rspec
+  - rubocop-rspec_rails
 
 AllCops:
   # Exclude automatically generated rails files for easier app:update's etc


### PR DESCRIPTION
Was getting this message, it looks like we need require the rspec rails cops seperatly:

`Error: `RSpec/Rails` cops have been extracted to the `rubocop-rspec_rails` gem. (obsolete configuration found in .rubocop-https---raw-githubusercontent-com-mynewsdesk-mnd-rubocop-master--rubocop-yml, please update it)`